### PR TITLE
New events for selecting the items

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -53,6 +53,9 @@ exports.init = function() {
         }
     }).on("changed.jstree", function (e, data) {
         if (!data.node) { return; }
+        var isFolder = data.node.type === "folder";
+        self[isFolder ? "selectedDir" : "selectedFile"] = data.node.original.path;
+        self.emit("selected." + (isFolder ? "folder" : "file"));
         self.selected = data.node.original.path;
         self.emit("changed", e, data);
     }).on("loaded.jstree", function (e, data) {


### PR DESCRIPTION
- Store in the self instance the selectedDir and selectedFile values.
- Emit `selected.(folder|file)` when the selection is changed.

Fixes #7.
